### PR TITLE
Documentation: Remove the URI `/wd/hub` from Selenium Grid addresses

### DIFF
--- a/docs/src/selenium-grid.md
+++ b/docs/src/selenium-grid.md
@@ -17,7 +17,7 @@ If you run distributed Selenium Grid, Playwright needs selenium nodes to be regi
 
 ```bash
 # Start selenium node
-SE_NODE_GRID_URL="http://<selenium-hub-ip>:4444/wd/hub" java -jar selenium-server-<version>.jar node
+SE_NODE_GRID_URL="http://<selenium-hub-ip>:4444" java -jar selenium-server-<version>.jar node
 ```
 
 ## Connecting Playwright to Selenium Grid
@@ -25,19 +25,19 @@ SE_NODE_GRID_URL="http://<selenium-hub-ip>:4444/wd/hub" java -jar selenium-serve
 To connect Playwright to **Selenium Grid 4**, set `SELENIUM_REMOTE_URL` environment variable pointing to your Selenium Grid Hub. Note that this only works for Google Chrome and Microsoft Edge.
 
 ```bash js
-SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444/wd/hub npx playwright test
+SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444 npx playwright test
 ```
 
 ```bash python
-SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444/wd/hub pytest --browser chromium
+SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444 pytest --browser chromium
 ```
 
 ```bash java
-SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444/wd/hub mvn test
+SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444 mvn test
 ```
 
 ```bash csharp
-SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444/wd/hub dotnet test
+SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444 dotnet test
 ```
 
 You don't have to change your code, just use your testing harness or [`method: BrowserType.launch`] as usual.
@@ -49,19 +49,19 @@ When using Selenium Grid Hub, you can [skip browser downloads](./browsers.md#ski
 If your grid requires additional capabilities to be set (for example, you use an external service), you can set `SELENIUM_REMOTE_CAPABILITIES` environment variable to provide JSON-serialized capabilities.
 
 ```bash js
-SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444/wd/hub SELENIUM_REMOTE_CAPABILITIES="{'mygrid:options':{os:'windows',username:'John',password:'secure'}}" npx playwright test
+SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444 SELENIUM_REMOTE_CAPABILITIES="{'mygrid:options':{os:'windows',username:'John',password:'secure'}}" npx playwright test
 ```
 
 ```bash python
-SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444/wd/hub SELENIUM_REMOTE_CAPABILITIES="{'mygrid:options':{os:'windows',username:'John',password:'secure'}}" pytest --browser chromium
+SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444 SELENIUM_REMOTE_CAPABILITIES="{'mygrid:options':{os:'windows',username:'John',password:'secure'}}" pytest --browser chromium
 ```
 
 ```bash java
-SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444/wd/hub SELENIUM_REMOTE_CAPABILITIES="{'mygrid:options':{os:'windows',username:'John',password:'secure'}}" mvn test
+SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444 SELENIUM_REMOTE_CAPABILITIES="{'mygrid:options':{os:'windows',username:'John',password:'secure'}}" mvn test
 ```
 
 ```bash csharp
-SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444/wd/hub SELENIUM_REMOTE_CAPABILITIES="{'mygrid:options':{os:'windows',username:'John',password:'secure'}}" dotnet test
+SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444 SELENIUM_REMOTE_CAPABILITIES="{'mygrid:options':{os:'windows',username:'John',password:'secure'}}" dotnet test
 ```
 
 ### Detailed logs
@@ -69,19 +69,19 @@ SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444/wd/hub SELENIUM_REMOTE_CAPABIL
 Run with `DEBUG=pw:browser*` environment variable to see how Playwright is connecting to Selenium Grid.
 
 ```bash js
-DEBUG=pw:browser* SELENIUM_REMOTE_URL=http://internal.grid:4444/wd/hub npx playwright test
+DEBUG=pw:browser* SELENIUM_REMOTE_URL=http://internal.grid:4444 npx playwright test
 ```
 
 ```bash python
-DEBUG=pw:browser* SELENIUM_REMOTE_URL=http://internal.grid:4444/wd/hub pytest --browser chromium
+DEBUG=pw:browser* SELENIUM_REMOTE_URL=http://internal.grid:4444 pytest --browser chromium
 ```
 
 ```bash java
-DEBUG=pw:browser* SELENIUM_REMOTE_URL=http://internal.grid:4444/wd/hub mvn test
+DEBUG=pw:browser* SELENIUM_REMOTE_URL=http://internal.grid:4444 mvn test
 ```
 
 ```bash csharp
-DEBUG=pw:browser* SELENIUM_REMOTE_URL=http://internal.grid:4444/wd/hub dotnet test
+DEBUG=pw:browser* SELENIUM_REMOTE_URL=http://internal.grid:4444 dotnet test
 ```
 
 If you file an issue, please include this log.
@@ -99,28 +99,28 @@ Here is an example of running selenium standalone and connecting Playwright to i
 First start Selenium.
 
 ```bash
-docker run -d -p 4444:4444 --shm-size="2g" -e SE_NODE_GRID_URL="http://localhost:4444/wd/hub" selenium/standalone-chrome:4.3.0-20220726
+docker run -d -p 4444:4444 --shm-size="2g" -e SE_NODE_GRID_URL="http://localhost:4444" selenium/standalone-chrome:4.3.0-20220726
 
 # Alternatively for arm architecture
-docker run -d -p 4444:4444 --shm-size="2g" -e SE_NODE_GRID_URL="http://localhost:4444/wd/hub" seleniarm/standalone-chromium:103.0
+docker run -d -p 4444:4444 --shm-size="2g" -e SE_NODE_GRID_URL="http://localhost:4444" seleniarm/standalone-chromium:103.0
 ```
 
 Then run Playwright.
 
 ```bash js
-SELENIUM_REMOTE_URL=http://localhost:4444/wd/hub npx playwright test
+SELENIUM_REMOTE_URL=http://localhost:4444 npx playwright test
 ```
 
 ```bash python
-SELENIUM_REMOTE_URL=http://localhost:4444/wd/hub pytest --browser chromium
+SELENIUM_REMOTE_URL=http://localhost:4444 pytest --browser chromium
 ```
 
 ```bash java
-SELENIUM_REMOTE_URL=http://localhost:4444/wd/hub mvn test
+SELENIUM_REMOTE_URL=http://localhost:4444 mvn test
 ```
 
 ```bash csharp
-SELENIUM_REMOTE_URL=http://localhost:4444/wd/hub dotnet test
+SELENIUM_REMOTE_URL=http://localhost:4444 dotnet test
 ```
 
 ### Hub and nodes mode
@@ -136,7 +136,7 @@ docker run -d -p 5555:5555 \
     -e SE_EVENT_BUS_HOST=<selenium-hub-ip> \
     -e SE_EVENT_BUS_PUBLISH_PORT=4442 \
     -e SE_EVENT_BUS_SUBSCRIBE_PORT=4443 \
-    -e SE_NODE_GRID_URL="http://<selenium-hub-ip>:4444/wd/hub"
+    -e SE_NODE_GRID_URL="http://<selenium-hub-ip>:4444"
     selenium/node-chrome:4.3.0-20220726
 
 # Alternatively for arm architecture
@@ -146,26 +146,26 @@ docker run -d -p 5555:5555 \
     -e SE_EVENT_BUS_HOST=<selenium-hub-ip> \
     -e SE_EVENT_BUS_PUBLISH_PORT=4442 \
     -e SE_EVENT_BUS_SUBSCRIBE_PORT=4443 \
-    -e SE_NODE_GRID_URL="http://<selenium-hub-ip>:4444/wd/hub"
+    -e SE_NODE_GRID_URL="http://<selenium-hub-ip>:4444"
     seleniarm/node-chromium:103.0
 ```
 
 Then run Playwright.
 
 ```bash js
-SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444/wd/hub npx playwright test
+SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444 npx playwright test
 ```
 
 ```bash python
-SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444/wd/hub pytest --browser chromium
+SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444 pytest --browser chromium
 ```
 
 ```bash java
-SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444/wd/hub mvn test
+SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444 mvn test
 ```
 
 ```bash csharp
-SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444/wd/hub dotnet test
+SELENIUM_REMOTE_URL=http://<selenium-hub-ip>:4444 dotnet test
 ```
 
 


### PR DESCRIPTION
Selenium 4 does not use `/wd/hub` as part of the Hub URI. 

As seen in the example https://www.selenium.dev/documentation/grid/getting_started/#metadata-in-tests, it registers the Selenium Grid URL simply as `http://gridUrl:4444` (no `/wd/hub`). 

When trying to access the URL ending with `/wd/hub`, it returns the message 'Unable to find handler for (GET) \u002fwd\u002fhub'.